### PR TITLE
Refactored tests to use in-memory H2 database instead of PostgreSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -183,6 +189,7 @@
             <properties>
                 <spring.profiles.active>prod</spring.profiles.active>
             </properties>
+
             <build>
                 <plugins>
                     <plugin>
@@ -194,6 +201,27 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>dev</id>
+            <properties>
+                <spring.profiles.active>dev</spring.profiles.active>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>testPostgres</id>
+            <properties>
+                <spring.profiles.active>testPostgres</spring.profiles.active>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>testH2</id>
+            <properties>
+                <spring.profiles.active>testH2</spring.profiles.active>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/src/main/java/com/javarush/jira/common/internal/config/DatabaseConfig.java
+++ b/src/main/java/com/javarush/jira/common/internal/config/DatabaseConfig.java
@@ -1,0 +1,44 @@
+package com.javarush.jira.common.internal.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+
+@Configuration
+public class DatabaseConfig {
+
+    private String dbUrl = "jdbc:postgresql://localhost:5433/jira-test";
+
+    @Value("${TEST_DB_USERNAME}")
+    private String dbUsername;
+
+    @Value("${TEST_DB_PASSWORD}")
+    private String dbPassword;
+
+    @Bean
+    @Profile("testPostgres")
+    public DataSource postgresDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(dbUrl);
+        dataSource.setUsername(dbUsername);
+        dataSource.setPassword(dbPassword);
+        return dataSource;
+    }
+
+    @Bean
+    @Profile("testH2")
+    public DataSource h2DataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+}

--- a/src/test/java/com/javarush/jira/AbstractControllerTest.java
+++ b/src/test/java/com/javarush/jira/AbstractControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 //https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-testing-spring-boot-applications
-@Sql(scripts = {"classpath:db/changelog.sql", "classpath:data.sql"}, config = @SqlConfig(encoding = "UTF-8"))
+@Sql(scripts = {"classpath:h2/changelog-testH2.sql", "classpath:h2/data-testH2.sql"}, config = @SqlConfig(encoding = "UTF-8"))
 @AutoConfigureMockMvc
 //https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-testing-spring-boot-applications-testing-with-mock-environment
 public abstract class AbstractControllerTest extends BaseTests {

--- a/src/test/java/com/javarush/jira/BaseTests.java
+++ b/src/test/java/com/javarush/jira/BaseTests.java
@@ -4,6 +4,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
+//@ActiveProfiles("test")
 abstract class BaseTests {
 }

--- a/src/test/java/com/javarush/jira/login/internal/web/UserControllerTest.java
+++ b/src/test/java/com/javarush/jira/login/internal/web/UserControllerTest.java
@@ -58,7 +58,7 @@ class UserControllerTest extends AbstractControllerTest {
 
     @Test
     void createWithLocation() throws Exception {
-        UserTo newTo = mapper.toTo(getNew());
+        UserTo newTo = mapper.toTo(getNew2());
         ResultActions action = perform(MockMvcRequestBuilders.post(REST_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(jsonWithPassword(newTo, newTo.getPassword())))
@@ -66,7 +66,7 @@ class UserControllerTest extends AbstractControllerTest {
 
         User created = USER_MATCHER.readFromJson(action);
         long newId = created.id();
-        User newUser = getNew();
+        User newUser = getNew2();
         newUser.setId(newId);
         USER_MATCHER.assertMatch(created, newUser);
         USER_MATCHER.assertMatch(repository.getExisted(newId), newUser);

--- a/src/test/java/com/javarush/jira/login/internal/web/UserTestData.java
+++ b/src/test/java/com/javarush/jira/login/internal/web/UserTestData.java
@@ -34,6 +34,10 @@ public class UserTestData {
         return new User(null, "new@gmail.com", "newPassword", "newFirstName", "newLastName", "newDisplayName", Role.DEV);
     }
 
+    public static User getNew2() {
+        return new User(null, "newtest@gmail.com", "newPassword", "newFirstName", "newLastName", "newDisplayName", Role.DEV);
+    }
+
     public static User getUpdated() {
         return new User(USER_ID, USER_MAIL, "updatedPassword", "updatedFirstName", "updatedLastName",
                 "updatedDisplayName", Role.DEV, Role.ADMIN);

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,8 +1,0 @@
-spring.cache.type: none
-spring:
-  init:
-    mode: always
-  datasource:
-    url: jdbc:postgresql://localhost:5433/jira-test
-    username: jira
-    password: JiraRush

--- a/src/test/resources/application-testH2.yaml
+++ b/src/test/resources/application-testH2.yaml
@@ -1,0 +1,10 @@
+spring.cache.type: none
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+
+  liquibase:
+    change-log: "classpath:h2/changelog-testH2.sql"

--- a/src/test/resources/application-testPostgres.yaml
+++ b/src/test/resources/application-testPostgres.yaml
@@ -1,0 +1,12 @@
+spring.cache.type: none
+spring:
+  init:
+    mode: always
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5433/jira-test
+    username: jira
+    password: JiraRush
+
+  liquibase:
+    change-log: "classpath:postgres/changelog-testPostgres.sql"

--- a/src/test/resources/h2/changelog-testH2.sql
+++ b/src/test/resources/h2/changelog-testH2.sql
@@ -1,0 +1,295 @@
+--liquibase formatted sql
+
+--changeset kmpk:init_schema
+DROP TABLE IF EXISTS USER_ROLE;
+DROP TABLE IF EXISTS CONTACT;
+DROP TABLE IF EXISTS MAIL_CASE;
+DROP TABLE IF EXISTS PROFILE;
+DROP TABLE IF EXISTS TASK_TAG;
+DROP TABLE IF EXISTS USER_BELONG;
+DROP TABLE IF EXISTS ACTIVITY;
+DROP TABLE IF EXISTS TASK;
+DROP TABLE IF EXISTS SPRINT;
+DROP TABLE IF EXISTS PROJECT;
+DROP TABLE IF EXISTS REFERENCE;
+DROP TABLE IF EXISTS ATTACHMENT;
+DROP TABLE IF EXISTS USERS;
+
+-- Create sequences
+--CREATE SEQUENCE USER_ROLE_ID_SEQ;
+--CREATE SEQUENCE CONTACT_ID_SEQ;
+--CREATE SEQUENCE MAIL_CASE_ID_SEQ;
+--CREATE SEQUENCE PROFILE_ID_SEQ;
+--CREATE SEQUENCE TASK_TAG_ID_SEQ;
+--CREATE SEQUENCE USER_BELONG_ID_SEQ;
+--CREATE SEQUENCE ACTIVITY_ID_SEQ;
+--CREATE SEQUENCE TASK_ID_SEQ;
+--CREATE SEQUENCE SPRINT_ID_SEQ;
+--CREATE SEQUENCE PROJECT_ID_SEQ;
+--CREATE SEQUENCE REFERENCE_ID_SEQ;
+--CREATE SEQUENCE ATTACHMENT_ID_SEQ;
+--CREATE SEQUENCE USERS_ID_SEQ;
+
+create table PROJECT
+(
+    ID          integer primary key,
+    CODE        varchar(32)   not null
+        constraint UK_PROJECT_CODE unique,
+    TITLE       varchar(1024) not null,
+    DESCRIPTION varchar(4096) not null,
+    TYPE_CODE   varchar(32)   not null,
+    STARTPOINT  timestamp,
+    ENDPOINT    timestamp,
+    PARENT_ID   bigint,
+    constraint FK_PROJECT_PARENT foreign key (PARENT_ID) references PROJECT (ID) on delete cascade
+);
+
+create table MAIL_CASE
+(
+    ID        integer primary key,
+    EMAIL     varchar(255) not null,
+    NAME      varchar(255) not null,
+    DATE_TIME timestamp    not null,
+    RESULT    varchar(255) not null,
+    TEMPLATE  varchar(255) not null
+);
+
+create table SPRINT
+(
+    ID          integer primary key,
+    STATUS_CODE varchar(32) not null,
+    STARTPOINT  timestamp,
+    ENDPOINT    timestamp,
+    CODE        varchar(32) not null,
+    PROJECT_ID  bigint      not null,
+    constraint FK_SPRINT_PROJECT foreign key (PROJECT_ID) references PROJECT (ID) on delete cascade
+);
+
+create table REFERENCE
+(
+    ID         integer primary key,
+    CODE       varchar(32)   not null,
+    REF_TYPE   smallint      not null,
+    ENDPOINT   timestamp,
+    STARTPOINT timestamp,
+    TITLE      varchar(1024) not null,
+    AUX        varchar,
+    constraint UK_REFERENCE_REF_TYPE_CODE unique (REF_TYPE, CODE)
+);
+
+create table USERS
+(
+    ID           integer primary key,
+    DISPLAY_NAME varchar(32)  not null
+        constraint UK_USERS_DISPLAY_NAME unique,
+    EMAIL        varchar(128) not null
+        constraint UK_USERS_EMAIL unique,
+    FIRST_NAME   varchar(32)  not null,
+    LAST_NAME    varchar(32),
+    PASSWORD     varchar(128) not null,
+    ENDPOINT     timestamp,
+    STARTPOINT   timestamp
+);
+
+create table PROFILE
+(
+    ID                 bigint primary key,
+    LAST_LOGIN         timestamp,
+    LAST_FAILED_LOGIN  timestamp,
+    MAIL_NOTIFICATIONS bigint,
+    constraint FK_PROFILE_USERS foreign key (ID) references USERS (ID) on delete cascade
+);
+
+create table CONTACT
+(
+    ID      bigint       not null,
+    CODE    varchar(32)  not null,
+    "VALUE" varchar(256) not null,
+    primary key (ID, CODE),
+    constraint FK_CONTACT_PROFILE foreign key (ID) references PROFILE (ID) on delete cascade
+);
+
+create table TASK
+(
+    ID          integer primary key,
+    TITLE       varchar(1024) not null,
+    TYPE_CODE   varchar(32)   not null,
+    STATUS_CODE varchar(32)   not null,
+    PROJECT_ID  bigint        not null,
+    SPRINT_ID   bigint,
+    PARENT_ID   bigint,
+    STARTPOINT  timestamp,
+    ENDPOINT    timestamp,
+    constraint FK_TASK_SPRINT foreign key (SPRINT_ID) references SPRINT (ID) on delete set null,
+    constraint FK_TASK_PROJECT foreign key (PROJECT_ID) references PROJECT (ID) on delete cascade,
+    constraint FK_TASK_PARENT_TASK foreign key (PARENT_ID) references TASK (ID) on delete cascade
+);
+
+create table ACTIVITY
+(
+    ID            integer primary key,
+    AUTHOR_ID     bigint not null,
+    TASK_ID       bigint not null,
+    UPDATED       timestamp,
+    COMMENT       varchar(4096),
+--     history of task field change
+    TITLE         varchar(1024),
+    DESCRIPTION   varchar(4096),
+    ESTIMATE      integer,
+    TYPE_CODE     varchar(32),
+    STATUS_CODE   varchar(32),
+    PRIORITY_CODE varchar(32)
+);
+
+create table TASK_TAG
+(
+    TASK_ID bigint      not null,
+    TAG     varchar(32) not null,
+    constraint UK_TASK_TAG unique (TASK_ID, TAG),
+    constraint FK_TASK_TAG foreign key (TASK_ID) references TASK (ID) on delete cascade
+);
+
+create table USER_BELONG
+(
+    ID             integer primary key,
+    OBJECT_ID      bigint      not null,
+    OBJECT_TYPE    smallint    not null,
+    USER_ID        bigint      not null,
+    USER_TYPE_CODE varchar(32) not null,
+    STARTPOINT     timestamp,
+    ENDPOINT       timestamp
+);
+
+create table ATTACHMENT
+(
+    ID          integer primary key,
+    NAME        varchar(128)  not null,
+    FILE_LINK   varchar(2048) not null,
+    OBJECT_ID   bigint        not null,
+    OBJECT_TYPE smallint      not null,
+    USER_ID     bigint        not null,
+    DATE_TIME   timestamp
+);
+
+create table USER_ROLE
+(
+    USER_ID bigint   not null,
+    ROLE    smallint not null,
+    constraint UK_USER_ROLE unique (USER_ID, ROLE),
+    constraint FK_USER_ROLE foreign key (USER_ID) references USERS (ID) on delete cascade
+);
+
+--changeset kmpk:populate_data
+--============ References =================
+insert into REFERENCE (ID, CODE, TITLE, REF_TYPE)
+-- TASK
+values (1, 'task', 'Task', 2),
+       (2, 'story', 'Story', 2),
+       (3, 'bug', 'Bug', 2),
+       (4, 'epic', 'Epic', 2),
+-- SPRINT_STATUS
+       (5, 'planning', 'Planning', 4),
+       (6, 'active', 'Active', 4),
+       (7, 'finished', 'Finished', 4),
+-- USER_TYPE
+       (8, 'author', 'Author', 5),
+       (9, 'developer', 'Developer', 5),
+       (10, 'reviewer', 'Reviewer', 5),
+       (11, 'tester', 'Tester', 5),
+-- PROJECT
+       (12, 'scrum', 'Scrum', 1),
+       (13, 'task_tracker', 'Task tracker', 1),
+-- CONTACT
+       (14, 'skype', 'Skype', 0),
+       (15, 'tg', 'Telegram', 0),
+       (16, 'mobile', 'Mobile', 0),
+       (17, 'phone', 'Phone', 0),
+       (18, 'website', 'Website', 0),
+       (19, 'linkedin', 'LinkedIn', 0),
+       (20, 'github', 'GitHub', 0),
+-- PRIORITY
+       (21, 'critical', 'Critical', 7),
+       (22, 'high', 'High', 7),
+       (23, 'normal', 'Normal', 7),
+       (24, 'low', 'Low', 7),
+       (25, 'neutral', 'Neutral', 7);
+
+insert into REFERENCE (ID, CODE, TITLE, REF_TYPE, AUX)
+-- MAIL_NOTIFICATION
+values (26, 'assigned', 'Assigned', 6, '1'),
+       (27, 'three_days_before_deadline', 'Three days before deadline', 6, '2'),
+       (28, 'two_days_before_deadline', 'Two days before deadline', 6, '4'),
+       (29, 'one_day_before_deadline', 'One day before deadline', 6, '8'),
+       (30, 'deadline', 'Deadline', 6, '16'),
+       (31, 'overdue', 'Overdue', 6, '32'),
+-- TASK_STATUS
+       (32, 'todo', 'ToDo', 3, 'in_progress,canceled'),
+       (33, 'in_progress', 'In progress', 3, 'ready_for_review,canceled'),
+       (34, 'ready_for_review', 'Ready for review', 3, 'review,canceled'),
+       (35, 'review', 'Review', 3, 'in_progress,ready_for_test,canceled'),
+       (36, 'ready_for_test', 'Ready for test', 3, 'test,canceled'),
+       (37, 'test', 'Test', 3, 'done,in_progress,canceled'),
+       (38, 'done', 'Done', 3, 'canceled'),
+       (39, 'canceled', 'Canceled', 3, null);
+
+--changeset gkislin:change_backtracking_tables
+
+
+create unique index UK_SPRINT_PROJECT_CODE on SPRINT (PROJECT_ID, CODE);
+
+--changeset ishlyakhtenkov:change_task_status_reference
+
+delete
+from REFERENCE
+where REF_TYPE = 3;
+insert into REFERENCE (ID, CODE, TITLE, REF_TYPE, AUX)
+values (40, 'todo', 'ToDo', 3, 'in_progress,canceled'),
+       (41, 'in_progress', 'In progress', 3, 'ready_for_review,canceled'),
+       (42, 'ready_for_review', 'Ready for review', 3, 'in_progress,review,canceled'),
+       (43, 'review', 'Review', 3, 'in_progress,ready_for_test,canceled'),
+       (44, 'ready_for_test', 'Ready for test', 3, 'review,test,canceled'),
+       (45, 'test', 'Test', 3, 'done,in_progress,canceled'),
+       (46, 'done', 'Done', 3, 'canceled'),
+       (47, 'canceled', 'Canceled', 3, null);
+
+--changeset gkislin:users_add_on_delete_cascade
+alter table ACTIVITY
+    add constraint FK_ACTIVITY_USERS foreign key (AUTHOR_ID) references USERS (ID) on delete cascade;
+
+alter table USER_BELONG
+    add constraint FK_USER_BELONG foreign key (USER_ID) references USERS (ID) on delete cascade;
+
+alter table ATTACHMENT
+    add constraint FK_ATTACHMENT foreign key (USER_ID) references USERS (ID) on delete cascade;
+
+--changeset valeriyemelyanov:change_user_type_reference
+
+delete
+from REFERENCE
+where REF_TYPE = 5;
+insert into REFERENCE (ID, CODE, TITLE, REF_TYPE)
+-- USER_TYPE
+values (48, 'project_author', 'Author', 5),
+       (49, 'project_manager', 'Manager', 5),
+       (50, 'sprint_author', 'Author', 5),
+       (51, 'sprint_manager', 'Manager', 5),
+       (52, 'task_author', 'Author', 5),
+       (53, 'task_developer', 'Developer', 5),
+       (54, 'task_reviewer', 'Reviewer', 5),
+       (55, 'task_tester', 'Tester', 5);
+
+--changeset apolik:refactor_reference_aux
+
+-- TASK_TYPE
+delete
+from REFERENCE
+where REF_TYPE = 3;
+insert into REFERENCE (ID, CODE, TITLE, REF_TYPE, AUX)
+values (56, 'todo', 'ToDo', 3, 'in_progress,canceled|'),
+       (57, 'in_progress', 'In progress', 3, 'ready_for_review,canceled|task_developer'),
+       (58, 'ready_for_review', 'Ready for review', 3, 'in_progress,review,canceled|'),
+       (59, 'review', 'Review', 3, 'in_progress,ready_for_test,canceled|task_reviewer'),
+       (60, 'ready_for_test', 'Ready for test', 3, 'review,test,canceled|'),
+       (61, 'test', 'Test', 3, 'done,in_progress,canceled|task_tester'),
+       (62, 'done', 'Done', 3, 'canceled|'),
+       (63, 'canceled', 'Canceled', 3, null);

--- a/src/test/resources/h2/data-testH2.sql
+++ b/src/test/resources/h2/data-testH2.sql
@@ -1,0 +1,77 @@
+---------  users ----------------------
+delete from USER_ROLE;
+delete from CONTACT;
+delete from PROFILE;
+delete from ACTIVITY;
+delete from TASK;
+delete from SPRINT;
+delete from PROJECT;
+delete from USERS;
+
+insert into USERS (ID, EMAIL, PASSWORD, FIRST_NAME, LAST_NAME, DISPLAY_NAME)
+values (1, 'user@gmail.com', '{noop}password', 'userFirstName', 'userLastName', 'userDisplayName'),
+       (2, 'admin@gmail.com', '{noop}admin', 'adminFirstName', 'adminLastName', 'adminDisplayName'),
+       (3, 'guest@gmail.com', '{noop}guest', 'guestFirstName', 'guestLastName', 'guestDisplayName'),
+       (4, 'manager@gmail.com', '{noop}manager', 'managerFirstName', 'managerLastName', 'managerDisplayName');
+
+-- 0 DEV
+-- 1 ADMIN
+-- 2 MANAGER
+
+insert into USER_ROLE (USER_ID, ROLE)
+values (1, 0),
+       (2, 0),
+       (2, 1),
+       (4, 2);
+
+insert into PROFILE (ID, LAST_FAILED_LOGIN, LAST_LOGIN, MAIL_NOTIFICATIONS)
+values (1, null, null, 49),
+       (2, null, null, 14);
+
+insert into CONTACT (ID, CODE, "VALUE")
+values (1, 'skype', 'userSkype'),
+       (1, 'mobile', '+01234567890'),
+       (1, 'website', 'user.com'),
+       (2, 'github', 'adminGitHub'),
+       (2, 'tg', 'adminTg');
+
+
+insert into PROJECT (ID, code, title, description, type_code, parent_id)
+values (1, 'PR1', 'PROJECT-1', 'test project 1', 'task_tracker', null),
+       (2, 'PR2', 'PROJECT-2', 'test project 2', 'task_tracker', 1);
+
+insert into SPRINT (ID, status_code, startpoint, endpoint, code, project_id)
+values (1, 'finished', '2023-05-01 08:05:10', '2023-05-07 17:10:01', 'SP-1.001', 1),
+       (2, 'active', '2023-05-01 08:06:00', null, 'SP-1.002', 1),
+       (3, 'active', '2023-05-01 08:07:00', null, 'SP-1.003', 1),
+       (4, 'planning', '2023-05-01 08:08:00', null, 'SP-1.004', 1),
+       (5, 'active', '2023-05-10 08:06:00', null, 'SP-2.001', 2),
+       (6, 'planning', '2023-05-10 08:07:00', null, 'SP-2.002', 2),
+       (7, 'planning', '2023-05-10 08:08:00', null, 'SP-2.003', 2);
+
+insert into TASK (ID, TITLE, TYPE_CODE, STATUS_CODE, PROJECT_ID, SPRINT_ID, STARTPOINT)
+values (1, 'Data', 'epic', 'in_progress', 1, 1, '2023-05-15 09:05:10'),
+       (2, 'Trees', 'epic', 'in_progress', 1, 1, '2023-05-15 12:05:10'),
+       (3, 'task-3', 'task', 'ready_for_test', 2, 5, '2023-06-14 09:28:10'),
+       (4, 'task-4', 'task', 'ready_for_review', 2, 5, '2023-06-14 09:28:10'),
+       (5, 'task-5', 'task', 'todo', 2, 5, '2023-06-14 09:28:10'),
+       (6, 'task-6', 'task', 'done', 2, 5, '2023-06-14 09:28:10'),
+       (7, 'task-7', 'task', 'canceled', 2, 5, '2023-06-14 09:28:10');
+
+
+insert into ACTIVITY(ID, AUTHOR_ID, TASK_ID, UPDATED, COMMENT, TITLE, DESCRIPTION, ESTIMATE, TYPE_CODE, STATUS_CODE,
+                     PRIORITY_CODE)
+values (1, 1, 1, '2023-05-15 09:05:10', null, 'Data', null, 3, 'epic', 'in_progress', 'low'),
+       (2, 2, 1, '2023-05-15 12:25:10', null, 'Data', null, null, null, null, 'normal'),
+       (3, 1, 1, '2023-05-15 14:05:10', null, 'Data', null, 4, null, null, null),
+       (4, 1, 2, '2023-05-15 12:05:10', null, 'Trees', 'Trees desc', 4, 'epic', 'in_progress', 'normal');
+
+insert into USER_BELONG (ID, OBJECT_ID, OBJECT_TYPE, USER_ID, USER_TYPE_CODE, STARTPOINT, ENDPOINT)
+values (1, 1, 2, 2, 'task_developer', '2023-06-14 08:35:10', '2023-06-14 08:55:00'),
+       (2, 1, 2, 2, 'task_reviewer', '2023-06-14 09:35:10', null),
+       (3, 1, 2, 1, 'task_developer', '2023-06-12 11:40:00', '2023-06-12 12:35:00'),
+       (4, 1, 2, 1, 'task_developer', '2023-06-13 12:35:00', null),
+       (5, 1, 2, 1, 'task_tester', '2023-06-14 15:20:00', null),
+       (6, 2, 2, 2, 'task_developer', '2023-06-08 07:10:00', null),
+       (7, 2, 2, 1, 'task_developer', '2023-06-09 14:48:00', null),
+       (8, 2, 2, 1, 'task_tester', '2023-06-10 16:37:00', null);

--- a/src/test/resources/postgres/changelog-testPostgres.sql
+++ b/src/test/resources/postgres/changelog-testPostgres.sql
@@ -1,0 +1,331 @@
+--liquibase formatted sql
+
+--changeset kmpk:init_schema
+DROP TABLE IF EXISTS USER_ROLE;
+DROP TABLE IF EXISTS CONTACT;
+DROP TABLE IF EXISTS MAIL_CASE;
+DROP
+SEQUENCE IF EXISTS MAIL_CASE_ID_SEQ;
+DROP TABLE IF EXISTS PROFILE;
+DROP TABLE IF EXISTS TASK_TAG;
+DROP TABLE IF EXISTS USER_BELONG;
+DROP
+SEQUENCE IF EXISTS USER_BELONG_ID_SEQ;
+DROP TABLE IF EXISTS ACTIVITY;
+DROP
+SEQUENCE IF EXISTS ACTIVITY_ID_SEQ;
+DROP TABLE IF EXISTS TASK;
+DROP
+SEQUENCE IF EXISTS TASK_ID_SEQ;
+DROP TABLE IF EXISTS SPRINT;
+DROP
+SEQUENCE IF EXISTS SPRINT_ID_SEQ;
+DROP TABLE IF EXISTS PROJECT;
+DROP
+SEQUENCE IF EXISTS PROJECT_ID_SEQ;
+DROP TABLE IF EXISTS REFERENCE;
+DROP
+SEQUENCE IF EXISTS REFERENCE_ID_SEQ;
+DROP TABLE IF EXISTS ATTACHMENT;
+DROP
+SEQUENCE IF EXISTS ATTACHMENT_ID_SEQ;
+DROP TABLE IF EXISTS USERS;
+DROP
+SEQUENCE IF EXISTS USERS_ID_SEQ;
+
+create table PROJECT
+(
+    ID bigserial primary key,
+    CODE        varchar(32)   not null
+        constraint UK_PROJECT_CODE unique,
+    TITLE       varchar(1024) not null,
+    DESCRIPTION varchar(4096) not null,
+    TYPE_CODE   varchar(32)   not null,
+    STARTPOINT  timestamp,
+    ENDPOINT    timestamp,
+    PARENT_ID   bigint,
+    constraint FK_PROJECT_PARENT foreign key (PARENT_ID) references PROJECT (ID) on delete cascade
+);
+
+create table MAIL_CASE
+(
+    ID bigserial primary key,
+    EMAIL     varchar(255) not null,
+    NAME      varchar(255) not null,
+    DATE_TIME timestamp    not null,
+    RESULT    varchar(255) not null,
+    TEMPLATE  varchar(255) not null
+);
+
+create table SPRINT
+(
+    ID bigserial primary key,
+    STATUS_CODE varchar(32)   not null,
+    STARTPOINT  timestamp,
+    ENDPOINT    timestamp,
+    TITLE       varchar(1024) not null,
+    PROJECT_ID  bigint        not null,
+    constraint FK_SPRINT_PROJECT foreign key (PROJECT_ID) references PROJECT (ID) on delete cascade
+);
+
+create table REFERENCE
+(
+    ID bigserial primary key,
+    CODE       varchar(32)   not null,
+    REF_TYPE   smallint      not null,
+    ENDPOINT   timestamp,
+    STARTPOINT timestamp,
+    TITLE      varchar(1024) not null,
+    AUX        varchar,
+    constraint UK_REFERENCE_REF_TYPE_CODE unique (REF_TYPE, CODE)
+);
+
+create table USERS
+(
+    ID bigserial primary key,
+    DISPLAY_NAME varchar(32)  not null
+        constraint UK_USERS_DISPLAY_NAME unique,
+    EMAIL        varchar(128) not null
+        constraint UK_USERS_EMAIL unique,
+    FIRST_NAME   varchar(32)  not null,
+    LAST_NAME    varchar(32),
+    PASSWORD     varchar(128) not null,
+    ENDPOINT     timestamp,
+    STARTPOINT   timestamp
+);
+
+create table PROFILE
+(
+    ID                 bigint primary key,
+    LAST_LOGIN         timestamp,
+    LAST_FAILED_LOGIN  timestamp,
+    MAIL_NOTIFICATIONS bigint,
+    constraint FK_PROFILE_USERS foreign key (ID) references USERS (ID) on delete cascade
+);
+
+create table CONTACT
+(
+    ID    bigint       not null,
+    CODE  varchar(32)  not null,
+    VALUE varchar(256) not null,
+    primary key (ID, CODE),
+    constraint FK_CONTACT_PROFILE foreign key (ID) references PROFILE (ID) on delete cascade
+);
+
+create table TASK
+(
+    ID bigserial primary key,
+    TITLE         varchar(1024) not null,
+    DESCRIPTION   varchar(4096) not null,
+    TYPE_CODE     varchar(32)   not null,
+    STATUS_CODE   varchar(32)   not null,
+    PRIORITY_CODE varchar(32)   not null,
+    ESTIMATE      integer,
+    UPDATED       timestamp,
+    PROJECT_ID    bigint        not null,
+    SPRINT_ID     bigint,
+    PARENT_ID     bigint,
+    STARTPOINT    timestamp,
+    ENDPOINT      timestamp,
+    constraint FK_TASK_SPRINT foreign key (SPRINT_ID) references SPRINT (ID) on delete set null,
+    constraint FK_TASK_PROJECT foreign key (PROJECT_ID) references PROJECT (ID) on delete cascade,
+    constraint FK_TASK_PARENT_TASK foreign key (PARENT_ID) references TASK (ID) on delete cascade
+);
+
+create table ACTIVITY
+(
+    ID bigserial primary key,
+    AUTHOR_ID     bigint not null,
+    TASK_ID       bigint not null,
+    UPDATED       timestamp,
+    COMMENT       varchar(4096),
+--     history of task field change
+    TITLE         varchar(1024),
+    DESCRIPTION   varchar(4096),
+    ESTIMATE      integer,
+    TYPE_CODE     varchar(32),
+    STATUS_CODE   varchar(32),
+    PRIORITY_CODE varchar(32),
+    constraint FK_ACTIVITY_USERS foreign key (AUTHOR_ID) references USERS (ID),
+    constraint FK_ACTIVITY_TASK foreign key (TASK_ID) references TASK (ID) on delete cascade
+);
+
+create table TASK_TAG
+(
+    TASK_ID bigint      not null,
+    TAG     varchar(32) not null,
+    constraint UK_TASK_TAG unique (TASK_ID, TAG),
+    constraint FK_TASK_TAG foreign key (TASK_ID) references TASK (ID) on delete cascade
+);
+
+create table USER_BELONG
+(
+    ID bigserial primary key,
+    OBJECT_ID      bigint      not null,
+    OBJECT_TYPE    smallint    not null,
+    USER_ID        bigint      not null,
+    USER_TYPE_CODE varchar(32) not null,
+    STARTPOINT     timestamp,
+    ENDPOINT       timestamp,
+    constraint FK_USER_BELONG foreign key (USER_ID) references USERS (ID)
+);
+create unique index UK_USER_BELONG on USER_BELONG (OBJECT_ID, OBJECT_TYPE, USER_ID, USER_TYPE_CODE);
+create index IX_USER_BELONG_USER_ID on USER_BELONG (USER_ID);
+
+create table ATTACHMENT
+(
+    ID bigserial primary key,
+    NAME        varchar(128)  not null,
+    FILE_LINK   varchar(2048) not null,
+    OBJECT_ID   bigint        not null,
+    OBJECT_TYPE smallint      not null,
+    USER_ID     bigint        not null,
+    DATE_TIME   timestamp,
+    constraint FK_ATTACHMENT foreign key (USER_ID) references USERS (ID)
+);
+
+create table USER_ROLE
+(
+    USER_ID bigint   not null,
+    ROLE    smallint not null,
+    constraint UK_USER_ROLE unique (USER_ID, ROLE),
+    constraint FK_USER_ROLE foreign key (USER_ID) references USERS (ID) on delete cascade
+);
+
+--changeset kmpk:populate_data
+--============ References =================
+insert into REFERENCE (CODE, TITLE, REF_TYPE)
+-- TASK
+values ('task', 'Task', 2),
+       ('story', 'Story', 2),
+       ('bug', 'Bug', 2),
+       ('epic', 'Epic', 2),
+-- SPRINT_STATUS
+       ('planning', 'Planning', 4),
+       ('active', 'Active', 4),
+       ('finished', 'Finished', 4),
+-- USER_TYPE
+       ('author', 'Author', 5),
+       ('developer', 'Developer', 5),
+       ('reviewer', 'Reviewer', 5),
+       ('tester', 'Tester', 5),
+-- PROJECT
+       ('scrum', 'Scrum', 1),
+       ('task_tracker', 'Task tracker', 1),
+-- CONTACT
+       ('skype', 'Skype', 0),
+       ('tg', 'Telegram', 0),
+       ('mobile', 'Mobile', 0),
+       ('phone', 'Phone', 0),
+       ('website', 'Website', 0),
+       ('vk', 'VK', 0),
+       ('linkedin', 'LinkedIn', 0),
+       ('github', 'GitHub', 0),
+-- PRIORITY
+       ('critical', 'Critical', 7),
+       ('high', 'High', 7),
+       ('normal', 'Normal', 7),
+       ('low', 'Low', 7),
+       ('neutral', 'Neutral', 7);
+
+insert into REFERENCE (CODE, TITLE, REF_TYPE, AUX)
+-- MAIL_NOTIFICATION
+values ('assigned', 'Assigned', 6, '1'),
+       ('three_days_before_deadline', 'Three days before deadline', 6, '2'),
+       ('two_days_before_deadline', 'Two days before deadline', 6, '4'),
+       ('one_day_before_deadline', 'One day before deadline', 6, '8'),
+       ('deadline', 'Deadline', 6, '16'),
+       ('overdue', 'Overdue', 6, '32'),
+-- TASK_STATUS
+       ('todo', 'ToDo', 3, 'in_progress,canceled'),
+       ('in_progress', 'In progress', 3, 'ready_for_review,canceled'),
+       ('ready_for_review', 'Ready for review', 3, 'review,canceled'),
+       ('review', 'Review', 3, 'in_progress,ready_for_test,canceled'),
+       ('ready_for_test', 'Ready for test', 3, 'test,canceled'),
+       ('test', 'Test', 3, 'done,in_progress,canceled'),
+       ('done', 'Done', 3, 'canceled'),
+       ('canceled', 'Canceled', 3, null);
+
+--changeset gkislin:change_backtracking_tables
+
+alter table SPRINT rename COLUMN TITLE to CODE;
+alter table SPRINT
+    alter column CODE type varchar (32);
+alter table SPRINT
+    alter column CODE set not null;
+create unique index UK_SPRINT_PROJECT_CODE on SPRINT (PROJECT_ID, CODE);
+
+ALTER TABLE TASK
+    DROP COLUMN DESCRIPTION;
+ALTER TABLE TASK
+    DROP COLUMN PRIORITY_CODE;
+ALTER TABLE TASK
+    DROP COLUMN ESTIMATE;
+ALTER TABLE TASK
+    DROP COLUMN UPDATED;
+
+--changeset ishlyakhtenkov:change_task_status_reference
+
+delete
+from REFERENCE
+where REF_TYPE = 3;
+insert into REFERENCE (CODE, TITLE, REF_TYPE, AUX)
+values ('todo', 'ToDo', 3, 'in_progress,canceled'),
+       ('in_progress', 'In progress', 3, 'ready_for_review,canceled'),
+       ('ready_for_review', 'Ready for review', 3, 'in_progress,review,canceled'),
+       ('review', 'Review', 3, 'in_progress,ready_for_test,canceled'),
+       ('ready_for_test', 'Ready for test', 3, 'review,test,canceled'),
+       ('test', 'Test', 3, 'done,in_progress,canceled'),
+       ('done', 'Done', 3, 'canceled'),
+       ('canceled', 'Canceled', 3, null);
+
+--changeset gkislin:users_add_on_delete_cascade
+
+alter table ACTIVITY
+    drop constraint FK_ACTIVITY_USERS,
+    add constraint FK_ACTIVITY_USERS foreign key (AUTHOR_ID) references USERS (ID) on delete cascade;
+
+alter table USER_BELONG
+    drop constraint FK_USER_BELONG,
+    add constraint FK_USER_BELONG foreign key (USER_ID) references USERS (ID) on delete cascade;
+
+alter table ATTACHMENT
+    drop constraint FK_ATTACHMENT,
+    add constraint FK_ATTACHMENT foreign key (USER_ID) references USERS (ID) on delete cascade;
+
+--changeset valeriyemelyanov:change_user_type_reference
+
+delete
+from REFERENCE
+where REF_TYPE = 5;
+insert into REFERENCE (CODE, TITLE, REF_TYPE)
+-- USER_TYPE
+values ('project_author', 'Author', 5),
+       ('project_manager', 'Manager', 5),
+       ('sprint_author', 'Author', 5),
+       ('sprint_manager', 'Manager', 5),
+       ('task_author', 'Author', 5),
+       ('task_developer', 'Developer', 5),
+       ('task_reviewer', 'Reviewer', 5),
+       ('task_tester', 'Tester', 5);
+
+--changeset apolik:refactor_reference_aux
+
+-- TASK_TYPE
+delete
+from REFERENCE
+where REF_TYPE = 3;
+insert into REFERENCE (CODE, TITLE, REF_TYPE, AUX)
+values ('todo', 'ToDo', 3, 'in_progress,canceled|'),
+       ('in_progress', 'In progress', 3, 'ready_for_review,canceled|task_developer'),
+       ('ready_for_review', 'Ready for review', 3, 'in_progress,review,canceled|'),
+       ('review', 'Review', 3, 'in_progress,ready_for_test,canceled|task_reviewer'),
+       ('ready_for_test', 'Ready for test', 3, 'review,test,canceled|'),
+       ('test', 'Test', 3, 'done,in_progress,canceled|task_tester'),
+       ('done', 'Done', 3, 'canceled|'),
+       ('canceled', 'Canceled', 3, null);
+
+--changeset ishlyakhtenkov:change_UK_USER_BELONG
+
+drop index UK_USER_BELONG;
+create unique index UK_USER_BELONG on USER_BELONG (OBJECT_ID, OBJECT_TYPE, USER_ID, USER_TYPE_CODE) where ENDPOINT is null;

--- a/src/test/resources/postgres/data-testPostgres.sql
+++ b/src/test/resources/postgres/data-testPostgres.sql
@@ -9,24 +9,24 @@ from PROFILE;
 delete
 from ACTIVITY;
 alter
-sequence ACTIVITY_ID_SEQ restart with 1;
+    sequence ACTIVITY_ID_SEQ restart with 1;
 delete
 from TASK;
 alter
-sequence TASK_ID_SEQ restart with 1;
+    sequence TASK_ID_SEQ restart with 1;
 delete
 from SPRINT;
 alter
-sequence SPRINT_ID_SEQ restart with 1;
+    sequence SPRINT_ID_SEQ restart with 1;
 delete
 from PROJECT;
 alter
-sequence PROJECT_ID_SEQ restart with 1;
+    sequence PROJECT_ID_SEQ restart with 1;
 
 delete
 from USERS;
 alter
-sequence USERS_ID_SEQ restart with 1;
+    sequence USERS_ID_SEQ restart with 1;
 
 insert into USERS (EMAIL, PASSWORD, FIRST_NAME, LAST_NAME, DISPLAY_NAME)
 values ('user@gmail.com', '{noop}password', 'userFirstName', 'userLastName', 'userDisplayName'),


### PR DESCRIPTION
## Summary
This pull request addresses the task of refactoring tests to use an in-memory H2 database instead of PostgreSQL. This involves defining two beans and selecting which one to use based on the active Spring profile. As H2 does not support all features available in PostgreSQL, the test data scripts have been simplified.

## Changes
- Created two beans for the H2 and PostgreSQL databases.
- Updated the application to select the appropriate bean based on the active Spring profile.
- Simplified the test data scripts to be compatible with H2.