### PR TITLE
Comprehensive tests for ProfileRestController

### DIFF
--- a/src/test/java/com/javarush/jira/profile/internal/web/ProfileRestControllerTest.java
+++ b/src/test/java/com/javarush/jira/profile/internal/web/ProfileRestControllerTest.java
@@ -1,8 +1,204 @@
 package com.javarush.jira.profile.internal.web;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.javarush.jira.AbstractControllerTest;
+import com.javarush.jira.profile.ContactTo;
+import com.javarush.jira.profile.ProfileTo;
+import com.javarush.jira.profile.internal.ProfileMapper;
+import com.javarush.jira.profile.internal.ProfileRepository;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.javarush.jira.login.internal.web.UserTestData.*;
+import static com.javarush.jira.profile.internal.web.ProfileTestData.USER_PROFILE_TO;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class ProfileRestControllerTest extends AbstractControllerTest {
+    public static final String REST_URL = "/api/profile";
+    @Autowired
+    protected ProfileMapper profileMapper;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private ProfileRepository profileRepository;
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test get user profile with auth user functionality")
+    void givenAuthUser_whenGet_thenSuccessResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(get(REST_URL));
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id", CoreMatchers.notNullValue()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.mailNotifications.size()", CoreMatchers.is(3)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contacts.size()", CoreMatchers.is(3)));
+    }
+
+    @Test
+    @DisplayName("Test get user profile with not auth user functionality")
+    void givenNotAuthUser_whenGet_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(get(REST_URL));
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status", CoreMatchers.is(401)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.detail", CoreMatchers.is("Full authentication is required to access this resource")));
+    }
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test update user profile with auth user functionality")
+    void givenProfileToAndAuthUser_whenUpdate_thenSuccessResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(USER_PROFILE_TO)));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("Test update user profile with not auth user functionality")
+    void givenProfileToAndNotAuthUser_whenUpdate_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(USER_PROFILE_TO)));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.status", CoreMatchers.is(401)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.detail", CoreMatchers.is("Full authentication is required to access this resource")));
+    }
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test update user profile with auth user and profile with large number of notifications functionality")
+    void givenProfileWithLargeNotificationsToAndAuthUser_whenUpdate_thenErrorResponse() throws Exception {
+        //given
+        ProfileTo profileToWithLargeNotifications = new ProfileTo(null,
+                IntStream.range(0, 1000).mapToObj(i -> "notification" + i).collect(Collectors.toSet()),
+                Set.of(new ContactTo("skype", "userSkype")));
+
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(profileToWithLargeNotifications)));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().is(422));
+    }
+
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test update user profile with auth user and invalid profile functionality")
+    void givenInvalidToToAndAuthUser_whenUpdate_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(ProfileTestData.getInvalidTo())));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test update user profile with auth user and unknown contact functionality")
+    void givenUnknownContactToAndAuthUser_whenUpdate_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(ProfileTestData.getWithUnknownContactTo())));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test update user profile with auth user and unknown notification functionality")
+    void givenUnknownNotificationToAndAuthUser_whenUpdate_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(ProfileTestData.getWithUnknownNotificationTo())));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test update user profile with auth user and HTML unsafe contact functionality")
+    void givenContactHtmlUnsafeToAndAuthUser_whenUpdate_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(put(REST_URL)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(ProfileTestData.getWithContactHtmlUnsafeTo())));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().is(422));
+    }
+
+    @Test
+    @WithUserDetails(value = USER_MAIL)
+    @DisplayName("Test get user profile with auth user and non-existing user functionality")
+    void givenNonExistingUser_whenGet_thenErrorResponse() throws Exception {
+        //given
+        //when
+        ResultActions result = perform(get(REST_URL + "/nonExistingUser"));
+
+        //then
+        result
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
 
 }


### PR DESCRIPTION
## Summary
This pull request introduces a comprehensive suite of tests for all public methods in the `ProfileRestController`. The goal is to ensure thorough testing of both successful and unsuccessful paths.

## Changes
- Implemented tests for all public methods of the `ProfileRestController`. Although there are only 2 methods, the number of test methods is greater, as it's necessary to verify both success and failure paths.
- Added tests for the `givenAuthUser_whenGet_thenSuccessResponse` method to ensure successful retrieval of the user profile when authenticated.
- Added tests for the `givenNotAuthUser_whenGet_thenErrorResponse` method to ensure proper error response when attempting to retrieve the user profile without authentication.
- Added tests for the `givenProfileToAndAuthUser_whenUpdate_thenSuccessResponse` method to ensure successful profile update when authenticated.
- Added tests for the `givenProfileToAndNotAuthUser_whenUpdate_thenErrorResponse` method to ensure proper error response when attempting to update the profile without authentication.
- Added tests for the `givenProfileWithLargeNotificationsToAndAuthUser_whenUpdate_thenErrorResponse` method to ensure proper error response when attempting to update the profile with a large number of notifications.
- Added tests for the `givenInvalidToToAndAuthUser_whenUpdate_thenErrorResponse` method to ensure proper error response when attempting to update the profile with invalid data.
- Added tests for the `givenUnknownContactToAndAuthUser_whenUpdate_thenErrorResponse` method to ensure proper error response when attempting to update the profile with an unknown contact.
- Added tests for the `givenUnknownNotificationToAndAuthUser_whenUpdate_thenErrorResponse` method to ensure proper error response when attempting to update the profile with an unknown notification.
- Added tests for the `givenContactHtmlUnsafeToAndAuthUser_whenUpdate_thenErrorResponse` method to ensure proper error response when attempting to update the profile with HTML unsafe contact information.
- Added tests for the `givenNonExistingUser_whenGet_thenErrorResponse` method to ensure proper error response when attempting to retrieve the profile of a non-existing user.

## Impact
These tests will help maintain the integrity of our application as we continue to develop and refactor our codebase. They will serve as a safety net, allowing us to make changes with confidence that we are not introducing regressions.