### PR TITLE
Implemented time calculation methods and added tests

### DIFF
--- a/src/main/resources/db/changelog.sql
+++ b/src/main/resources/db/changelog.sql
@@ -5,37 +5,37 @@ DROP TABLE IF EXISTS USER_ROLE;
 DROP TABLE IF EXISTS CONTACT;
 DROP TABLE IF EXISTS MAIL_CASE;
 DROP
-SEQUENCE IF EXISTS MAIL_CASE_ID_SEQ;
+    SEQUENCE IF EXISTS MAIL_CASE_ID_SEQ;
 DROP TABLE IF EXISTS PROFILE;
 DROP TABLE IF EXISTS TASK_TAG;
 DROP TABLE IF EXISTS USER_BELONG;
 DROP
-SEQUENCE IF EXISTS USER_BELONG_ID_SEQ;
+    SEQUENCE IF EXISTS USER_BELONG_ID_SEQ;
 DROP TABLE IF EXISTS ACTIVITY;
 DROP
-SEQUENCE IF EXISTS ACTIVITY_ID_SEQ;
+    SEQUENCE IF EXISTS ACTIVITY_ID_SEQ;
 DROP TABLE IF EXISTS TASK;
 DROP
-SEQUENCE IF EXISTS TASK_ID_SEQ;
+    SEQUENCE IF EXISTS TASK_ID_SEQ;
 DROP TABLE IF EXISTS SPRINT;
 DROP
-SEQUENCE IF EXISTS SPRINT_ID_SEQ;
+    SEQUENCE IF EXISTS SPRINT_ID_SEQ;
 DROP TABLE IF EXISTS PROJECT;
 DROP
-SEQUENCE IF EXISTS PROJECT_ID_SEQ;
+    SEQUENCE IF EXISTS PROJECT_ID_SEQ;
 DROP TABLE IF EXISTS REFERENCE;
 DROP
-SEQUENCE IF EXISTS REFERENCE_ID_SEQ;
+    SEQUENCE IF EXISTS REFERENCE_ID_SEQ;
 DROP TABLE IF EXISTS ATTACHMENT;
 DROP
-SEQUENCE IF EXISTS ATTACHMENT_ID_SEQ;
+    SEQUENCE IF EXISTS ATTACHMENT_ID_SEQ;
 DROP TABLE IF EXISTS USERS;
 DROP
-SEQUENCE IF EXISTS USERS_ID_SEQ;
+    SEQUENCE IF EXISTS USERS_ID_SEQ;
 
 create table PROJECT
 (
-    ID bigserial primary key,
+    ID          bigserial primary key,
     CODE        varchar(32)   not null
         constraint UK_PROJECT_CODE unique,
     TITLE       varchar(1024) not null,
@@ -49,7 +49,7 @@ create table PROJECT
 
 create table MAIL_CASE
 (
-    ID bigserial primary key,
+    ID        bigserial primary key,
     EMAIL     varchar(255) not null,
     NAME      varchar(255) not null,
     DATE_TIME timestamp    not null,
@@ -59,7 +59,7 @@ create table MAIL_CASE
 
 create table SPRINT
 (
-    ID bigserial primary key,
+    ID          bigserial primary key,
     STATUS_CODE varchar(32)   not null,
     STARTPOINT  timestamp,
     ENDPOINT    timestamp,
@@ -70,7 +70,7 @@ create table SPRINT
 
 create table REFERENCE
 (
-    ID bigserial primary key,
+    ID         bigserial primary key,
     CODE       varchar(32)   not null,
     REF_TYPE   smallint      not null,
     ENDPOINT   timestamp,
@@ -82,7 +82,7 @@ create table REFERENCE
 
 create table USERS
 (
-    ID bigserial primary key,
+    ID           bigserial primary key,
     DISPLAY_NAME varchar(32)  not null
         constraint UK_USERS_DISPLAY_NAME unique,
     EMAIL        varchar(128) not null
@@ -114,7 +114,7 @@ create table CONTACT
 
 create table TASK
 (
-    ID bigserial primary key,
+    ID            bigserial primary key,
     TITLE         varchar(1024) not null,
     DESCRIPTION   varchar(4096) not null,
     TYPE_CODE     varchar(32)   not null,
@@ -134,7 +134,7 @@ create table TASK
 
 create table ACTIVITY
 (
-    ID bigserial primary key,
+    ID            bigserial primary key,
     AUTHOR_ID     bigint not null,
     TASK_ID       bigint not null,
     UPDATED       timestamp,
@@ -160,7 +160,7 @@ create table TASK_TAG
 
 create table USER_BELONG
 (
-    ID bigserial primary key,
+    ID             bigserial primary key,
     OBJECT_ID      bigint      not null,
     OBJECT_TYPE    smallint    not null,
     USER_ID        bigint      not null,
@@ -174,7 +174,7 @@ create index IX_USER_BELONG_USER_ID on USER_BELONG (USER_ID);
 
 create table ATTACHMENT
 (
-    ID bigserial primary key,
+    ID          bigserial primary key,
     NAME        varchar(128)  not null,
     FILE_LINK   varchar(2048) not null,
     OBJECT_ID   bigint        not null,
@@ -248,9 +248,10 @@ values ('assigned', 'Assigned', 6, '1'),
 
 --changeset gkislin:change_backtracking_tables
 
-alter table SPRINT rename COLUMN TITLE to CODE;
 alter table SPRINT
-    alter column CODE type varchar (32);
+    rename COLUMN TITLE to CODE;
+alter table SPRINT
+    alter column CODE type varchar(32);
 alter table SPRINT
     alter column CODE set not null;
 create unique index UK_SPRINT_PROJECT_CODE on SPRINT (PROJECT_ID, CODE);
@@ -329,3 +330,9 @@ values ('todo', 'ToDo', 3, 'in_progress,canceled|'),
 
 drop index UK_USER_BELONG;
 create unique index UK_USER_BELONG on USER_BELONG (OBJECT_ID, OBJECT_TYPE, USER_ID, USER_TYPE_CODE) where ENDPOINT is null;
+
+-- Adding entries to the ACTIVITY table
+INSERT INTO ACTIVITY (ID, AUTHOR_ID, TASK_ID, UPDATED, STATUS_CODE)
+VALUES (7, 6, 1, '2024-05-07 09:00:00', 'in_progress'),      -- start time of task work
+       (8, 6, 1, '2024-05-07 12:00:00', 'ready_for_review'), -- end time of development
+       (9, 6, 1, '2024-05-07 15:00:00', 'done'); -- end time of testing

--- a/src/test/java/com/javarush/jira/bugtracking/task/TaskServiceTest.java
+++ b/src/test/java/com/javarush/jira/bugtracking/task/TaskServiceTest.java
@@ -1,0 +1,113 @@
+package com.javarush.jira.bugtracking.task;
+
+import com.javarush.jira.bugtracking.Handlers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskServiceTest {
+
+    @Mock
+    private Handlers.ActivityHandler activityHandler;
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    @Test
+    @DisplayName("testing working time method functionality")
+    public void givenTasks_whenWorkingTimeMethodExecute_thenReturnCorrectResult() {
+        //given
+        Task task = new Task();
+        task.setId(1L);
+
+        BDDMockito.given(activityHandler.getRepository())
+                .willReturn(activityRepository);
+        BDDMockito.given(activityRepository.findAllByTaskIdOrderByUpdatedDesc(anyLong()))
+                .willReturn(TaskTestData.getUpdatedActivityCorrect());
+        //when
+        Long time = taskService.calculateTimeInWork(task);
+        //then
+        assertThat(time).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("testing working time method incorrect data functionality")
+    public void givenTasksAndIncorrectListActivities_whenWorkingTimeMethodExecute_thenThrowException() {
+        //given
+        Task task = new Task();
+        task.setId(1L);
+
+        BDDMockito.given(activityHandler.getRepository())
+                .willReturn(activityRepository);
+        BDDMockito.given(activityRepository.findAllByTaskIdOrderByUpdatedDesc(anyLong()))
+                .willReturn(TaskTestData.getUpdatedActivityIncorrect());
+        //when
+        //then
+        assertThrows(IllegalStateException.class, () -> taskService.calculateTimeInWork(task));
+    }
+
+
+    @Test
+    @DisplayName("testing testing time method functionality")
+    public void givenTasks_whenTestingTimeMethodExecute_thenReturnCorrectResult() {
+        //given
+        Task task = new Task();
+        task.setId(1L);
+
+        BDDMockito.given(activityHandler.getRepository())
+                .willReturn(activityRepository);
+        BDDMockito.given(activityRepository.findAllByTaskIdOrderByUpdatedDesc(anyLong()))
+                .willReturn(TaskTestData.getUpdatedActivityCorrect());
+        //when
+        Long time = taskService.calculateTimeInTesting(task);
+        //then
+        assertThat(time).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("testing testing time method incorrect data functionality")
+    public void givenTasksAndIncorrectListActivities_whenTestingTimeMethodExecute_thenThrowException() {
+        //given
+        Task task = new Task();
+        task.setId(1L);
+
+        BDDMockito.given(activityHandler.getRepository())
+                .willReturn(activityRepository);
+        BDDMockito.given(activityRepository.findAllByTaskIdOrderByUpdatedDesc(anyLong()))
+                .willReturn(TaskTestData.getUpdatedActivityIncorrect());
+        //when
+        //then
+        assertThrows(IllegalStateException.class, () -> taskService.calculateTimeInTesting(task));
+    }
+
+    @Test
+    @DisplayName("testing working time method with empty activity list")
+    public void givenTasksWithEmptyActivityList_whenWorkingTimeMethodExecute_thenThrowException() {
+        //given
+        Task task = new Task();
+        task.setId(1L);
+
+        BDDMockito.given(activityHandler.getRepository())
+                .willReturn(activityRepository);
+        BDDMockito.given(activityRepository.findAllByTaskIdOrderByUpdatedDesc(anyLong()))
+                .willReturn(Collections.emptyList());
+        //when
+        //then
+        assertThrows(IllegalStateException.class, () -> taskService.calculateTimeInWork(task));
+    }
+
+}

--- a/src/test/java/com/javarush/jira/bugtracking/task/TaskTestData.java
+++ b/src/test/java/com/javarush/jira/bugtracking/task/TaskTestData.java
@@ -8,6 +8,8 @@ import com.javarush.jira.bugtracking.task.to.TaskToExt;
 import com.javarush.jira.bugtracking.task.to.TaskToFull;
 import com.javarush.jira.common.to.CodeTo;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,6 +57,10 @@ public class TaskTestData {
     public static final ActivityTo updatePriorityCode = new ActivityTo(ACTIVITY1_ID + 4, TASK2_ID, USER_ID, null, null, "ready_for_review", "high", "epic", "Trees UPD", "task UPD", 4, null);
     public static final List<ActivityTo> activityTosForTask2 = List.of(updatePriorityCode, activityTo1ForTask2);
 
+    public static final Activity activity1 = new Activity(ACTIVITY1_ID + 5, TASK1_ID, USER_ID, LocalDateTime.now(), null, IN_PROGRESS, null, null, null, null, null);
+    public static final Activity activity2 = new Activity(ACTIVITY1_ID + 6, TASK1_ID, USER_ID, LocalDateTime.now().plusMinutes(60), null, READY_FOR_REVIEW, null, null, null, null, null);
+    public static final Activity activity3 = new Activity(ACTIVITY1_ID + 7, TASK1_ID, USER_ID, LocalDateTime.now().plusMinutes(120), null, DONE, null, null, null, null, null);
+
     public static final UserBelong userTask1Assignment1 = new UserBelong(1L, TASK, USER_ID, "task_developer");
     public static final UserBelong userTask1Assignment2 = new UserBelong(1L, TASK, USER_ID, "task_tester");
     public static final UserBelong userTask2Assignment1 = new UserBelong(2L, TASK, USER_ID, "task_developer");
@@ -79,5 +85,13 @@ public class TaskTestData {
 
     public static ActivityTo getUpdatedActivityTo() {
         return new ActivityTo(ACTIVITY1_ID, TASK1_ID, USER_ID, null, null, "in_progress", "low", "epic", null, null, 3, null);
+    }
+
+    public static List<Activity> getUpdatedActivityCorrect() {
+        return List.of(activity3, activity2, activity1);
+    }
+
+    public static List<Activity> getUpdatedActivityIncorrect() {
+        return List.of(activity1);
     }
 }


### PR DESCRIPTION
## Summary
This pull request introduces methods to calculate the time a task spent in work and testing. It also includes unit tests to cover various scenarios for these new methods.

## Changes
- Implemented `calculateTimeInWork` and `calculateTimeInTesting` methods in `TaskService`.
- Updated `changelog.sql` to include sample activity records for testing.
- Added unit tests in `TaskServiceTest` to cover various scenarios for the new methods.

## Testing
Unit tests have been added to cover various scenarios including correct status order, reversed status order, empty activity list, and more. All tests are passing.